### PR TITLE
Update 1.2

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -32,7 +32,7 @@ public class Main {
             System.out.println("\u001B[34m" + "No Input " + "\u001B[0m");
         else{
             try {
-                //to 'catch' parser errors as a result of wrong input - technically it's not catched, just a 'break', since it can't be catched here
+                //to 'catch' parser errors as a result of wrong input - technically it's not caught, just a 'break', since it can't be caught here
                 ByteArrayOutputStream bas = new ByteArrayOutputStream();
                 PrintStream err = new PrintStream(bas);
                 PrintStream old = System.err;
@@ -53,7 +53,7 @@ public class Main {
                 }
                 else {
                     System.out.println(input);
-                    BetaReduction.betaReduction(input, out);
+                    BetaReduction.betaReduction(input, out, "","");
                 }
             } catch (RecognitionException e) {
                 e.printStackTrace();

--- a/src/main/java/app/gui/Gui.java
+++ b/src/main/java/app/gui/Gui.java
@@ -8,6 +8,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 import javafx.stage.Stage;
 import operation.BetaReduction;
 
@@ -57,6 +58,15 @@ public class Gui extends Application {
             }catch (Exception ignored) {}
             if(!tmp.getPanes().isEmpty())
                 accordion.getPanes().add(tmp.getPanes().remove(0));
+            if(accordion.getPanes().get(0).getContent() instanceof TextFlow) {
+                Text lastTextLineOfFirstPane = (Text) ((TextFlow) accordion.getPanes().get(0).getContent()).getChildren().get(((TextFlow) accordion.getPanes().get(0).getContent()).getChildren().size() - 1);
+                if (lastTextLineOfFirstPane.getText().contains("endless")
+                        && tmp.getPanes().size() > 1) { //contains endless loop build up
+                    TextFlow tmpTF = new TextFlow();
+                    tmpTF.getChildren().addAll(accordion.getPanes().get(0).getContent(), new Text("\nPress 'end' or 'next' to see build up."));
+                    accordion.getPanes().get(0).setContent(tmpTF);
+                }
+            }
             long elapsedTime = System.currentTimeMillis() - start;
             time.setText("time: "+elapsedTime +"ms");
         });
@@ -73,6 +83,15 @@ public class Gui extends Application {
             }catch (Exception ignored) {}
             if(!tmp.getPanes().isEmpty())
                 accordion.getPanes().add(tmp.getPanes().remove(0));
+            if(accordion.getPanes().get(0).getContent() instanceof TextFlow) {
+                Text lastTextLineOfFirstPane = (Text) ((TextFlow) accordion.getPanes().get(0).getContent()).getChildren().get(((TextFlow) accordion.getPanes().get(0).getContent()).getChildren().size() - 1);
+                if (lastTextLineOfFirstPane.getText().contains("endless")
+                        && tmp.getPanes().size() > 1) { //contains endless loop build up
+                    TextFlow tmpTF = new TextFlow();
+                    tmpTF.getChildren().addAll(accordion.getPanes().get(0).getContent(), new Text("\nPress 'end' or 'next' to see build up."));
+                    accordion.getPanes().get(0).setContent(tmpTF);
+                }
+            }
             long elapsedTime = System.currentTimeMillis() - start;
             time.setText("time: "+elapsedTime +"ms");
         });

--- a/src/main/java/model/Input.java
+++ b/src/main/java/model/Input.java
@@ -9,6 +9,10 @@ public class Input{
         inputList = new ArrayList<>();
     }
 
+    public Input(ArrayList<LambdaExpression> lambdaExpressions){
+        this.inputList = lambdaExpressions;
+    }
+
     public void addTerm(Term term){
         inputList.add(term);
     }
@@ -33,11 +37,15 @@ public class Input{
         return inputList.get(i);
     }
 
+    public LambdaExpression removeListIndex(int i){
+        return inputList.remove(i);
+    }
+
     public void setInputListIndex(int i, LambdaExpression lambdaExpression){
         inputList.set(i,lambdaExpression);
     }
 
-    public void removeInputListIndex(int i){
+    public void deleteListIndex(int i){
         inputList.remove(i);
     }
 

--- a/src/main/java/model/Term.java
+++ b/src/main/java/model/Term.java
@@ -171,6 +171,34 @@ public class Term extends LambdaExpression{
         return content.get(0) instanceof Term;
     }
 
+    public boolean containsTermAfterBound(){
+        if(content.get(0) instanceof MultiBound)
+            return content.get(1) instanceof Term;
+        else
+        if(content.get(0) instanceof SingleBound)
+            for(int i=1; i<content.size();){
+                if(content.get(i) instanceof SingleBound)
+                    i++;
+                else
+                    return content.get(i) instanceof Term;
+            }
+        return false;
+    }
+
+    public Term getTermAfterBound(){
+        if(content.get(0) instanceof MultiBound)
+            return (Term) content.get(1);
+        else
+        if(content.get(0) instanceof SingleBound)
+            for(int i=1; i<content.size();){
+                if(content.get(i) instanceof SingleBound)
+                    i++;
+                else
+                    return (Term) content.get(i);
+            }
+        return null;
+    }
+
     public void replaceVariables(Variable variable, LambdaExpression lambdaExpression){
         for(int i=0; i<content.size(); i++)
             if(content.get(i) instanceof Variable && ((Variable) content.get(i)).compare(variable))

--- a/src/test/java/InputTest.java
+++ b/src/test/java/InputTest.java
@@ -9,6 +9,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -16,6 +18,11 @@ import java.io.PrintStream;
 
 public class InputTest {
     private final boolean showCalculation = true;
+
+    @Before
+    public void clear(){
+        BetaReduction.resetCount();
+    }
 
     @Test
     public void test001(){
@@ -143,13 +150,19 @@ public class InputTest {
         test(inputString,"((uu)z)x\r");
     }
 
+    //ignored since term structure is added in 1.2 and it's endless loop, which result depends on the number of circles
+    @Deprecated
     @Test
+    @Ignore
     public void test022(){
         String inputString = "(Ly.(Lx.Ly.xx)(Lx.Ly.xx))";
         test(inputString,"(λy.(λx.λy.xx)(λx.λy.xx))\r");
     }
 
+    //ignored since term structure is added in 1.2 and it's endless loop, which result depends on the number of circles
+    @Deprecated
     @Test
+    @Ignore
     public void test023(){
         String inputString = "(Ly.(Lxy.xx)(Lxy.xx))";
         test(inputString,"(λy.(λxy.xx)(λxy.xx))\r");
@@ -240,6 +253,47 @@ public class InputTest {
         test(inputString,"(λabcdefghijklmnopqrstuvwxyz.xx)x\r");
     }
 
+    @Test
+    public void test038(){
+        String inputString = "(Lxyzu.(Ly.xy)xxyzux)yx";
+        test(inputString,"(λzu.(yy)yxzuy)\r");
+    }
+
+    @Test
+    public void test039(){
+        String inputString = "(Lx.Ly.Lz.Lu.(Ly.xy)xxyzux)yx";
+        test(inputString,"(λz.λu.(yy)yxzuy)\r");
+    }
+
+    @Test
+    public void test040(){
+        String inputString = "(Lxyzu.(Lp.xp)xxyzux)yx";
+        test(inputString,"(λzu.(yy)yxzuy)\r");
+    }
+    @Test
+    public void test041(){
+        String inputString = "(Lx.Ly.Lz.Lu.(Lp.xp)xxyzux)yx";
+        test(inputString,"(λz.λu.(yy)yxzuy)\r");
+    }
+
+    @Test
+    public void test042(){
+        String inputString = "(Lxyzu.(Lyx.xy)xxyzux)yx";
+        test(inputString,"(λzu.(yy)xzuy)\r");
+    }
+
+    @Test
+    public void test043(){
+        String inputString = "(Lx.Ly.Lz.Lu.(Lyx.xy)xxyzux)yx";
+        test(inputString,"(λz.λu.(yy)xzuy)\r");
+    }
+
+    @Test
+    public void test044(){
+        String inputString = "(Lx.xx)(Lx.xx)";
+        test(inputString,"(λx.xx)(λx.xx)\r");
+    }
+
     public void test(String inputString, String expected){
         PrintStream stdout = System.out;
 
@@ -272,7 +326,7 @@ public class InputTest {
             System.out.println("output:");
             System.out.println(input.toString());
 
-            BetaReduction.betaReduction(input, null);
+            BetaReduction.betaReduction(input, null,"","");
 
         } catch (RecognitionException e) {
             e.printStackTrace();


### PR DESCRIPTION
added solution for terms with the structure of
- (Lxyzu.(Ly.xy)xxyzux)yx [2 alpha conversions necessary]
- (Lxyzu.(Lp.xp)xxyzux)yx [1 alpha conversion necessary]
(inner term after bounds)

endless loops which expand can now show build up

BetaReduction
- added solution for new term structure
- changed count in reduce() from == to >=
- added function parameters preString and postString to have new term structure match output in gui, therefore new if/else statements are added
- added count/throw EndlessLoopException in betaReduction() to stop e.g. (Lx.xx)(Lx.xxx) from running endless
- betaReduction() now returns Input to overwrite input variable in context to new term structure

Gui
- changed textField.setOnAction and "start" button.setOnAction to add endless loop build up hint

Input
- added new constructor with ArrayList<LambdaExpression> parameter
- added removeListIndex()
- renamed old removeInputListIndex() to deleteListIndex()

InputTest
- added @Before clear() to reset count variable
- tests 022 and 023 will be ignored since term structure is added in 1.2 and it's endless loop, which result depends on the number of circles
- added 7 new tests
- matched new betaReduction() call

Main
- matched new betaReduction() call

Term
- added function containsTermAfterBound()
- added function getTermAfterBound()